### PR TITLE
Support for manifest version 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
 		}
   ],
   "background": {
-    "scripts": [
+    "service_worker": [
       "jquery-3.3.1.slim.min.js"
     ]
   },


### PR DESCRIPTION
In order to support more recent browsers, the background.scripts reference (in JSON) needs to be changed to background.service_worker. 

When importing the library on recent versions of chrome using `load unpacked` you receive this error message:  
```
The "background.scripts" key cannot be used with manifest_version 3. Use the "background.service_worker" key instead.
Could not load manifest.
```

By simply changing the reference, the plugin can be successfully installed and used with no future issues.

_By the way, this project is amazing!_